### PR TITLE
Use /DYNAMICBASE linker option

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -20,8 +20,6 @@ TARGET_CPU = x86
 !endif
 !endif
 
-BASEADDR = 0x60500000
-
 !ifdef DEBUG
 DBGFLG = d
 !else
@@ -58,7 +56,7 @@ CPPFLAGS = $(CPPFLAGS) /DUSE_VTAB /DPERL_5_8_COMPAT /DNAMEGROUP_RIGHTMOST
 CPPFLAGS = $(CPPFLAGS) /DUSE_ONIGMO_6
 !endif
 LD = link
-LDFLAGS = /DLL /nologo /MAP /BASE:$(BASEADDR) /merge:.rdata=.text
+LDFLAGS = /DLL /nologo /MAP /DYNAMICBASE /merge:.rdata=.text
 
 !ifdef USE_MSVCRT
 CPPFLAGS = $(CPPFLAGS) /MD


### PR DESCRIPTION
I'd like to use `/DYNAMICBASE` linker option instead of the `/BASE` option.

The motivation here is I tried to build `bregonig.dll` for arm64 architecture and the `/DYNAMICBASE` option needs to be used for that. (Please refer https://github.com/sakura-editor/sakura/issues/2042#issuecomment-2828660738)

https://learn.microsoft.com/en-us/cpp/build/reference/base-base-address?view=msvc-170

https://learn.microsoft.com/en-us/cpp/build/reference/dynamicbase-use-address-space-layout-randomization?view=msvc-170
